### PR TITLE
Update README and tests for ddev add-on get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Uses [typesense official image](https://hub.docker.com/r/typesense/typesense/)
 
-`ddev get torhoehn/ddev-typesense`
+`ddev add-on get torhoehn/ddev-typesense`
+
+For DDEV versions prior to v1.23.5, use `ddev get torhoehn/ddev-typesense`.
 
 ## Configuration
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -25,8 +25,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
@@ -34,8 +34,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get torhoehn/ddev-typesense with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get torhoehn/ddev-typesense
+  echo "# ddev add-on get torhoehn/ddev-typesense with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get torhoehn/ddev-typesense
   ddev restart >/dev/null
   health_checks
 }


### PR DESCRIPTION
Update installation command and tests to use `ddev add-on get` instead of `ddev get`.

* **README.md**
  - Change installation command to `ddev add-on get torhoehn/ddev-typesense`
  - Add a hint for older versions to use `ddev get torhoehn/ddev-typesense`

* **tests/test.bats**
  - Update test descriptions to use `ddev add-on get` instead of `ddev get`
  - Update example command in the test to `ddev add-on get torhoehn/ddev-typesense`

